### PR TITLE
json_to_yaml: fix keys for route/route6 objects

### DIFF
--- a/ripe.py
+++ b/ripe.py
@@ -230,10 +230,16 @@ def json_to_yaml(json_payload):
     objects = {}
 
     for i in json_payload["objects"]["object"]:
-        objects[i["primary-key"]["attribute"][0]["value"]] = []
+        type = i["type"]
+        primaryKey = i["primary-key"]["attribute"]
+        objectKey = primaryKey[0]["value"]
+        if type == "route" or type == "route6":
+            origin = primaryKey[1]["value"]
+            objectKey = f"{objectKey}{origin}"
+        objects[objectKey] = []
         for j in i["attributes"]["attribute"]:
             if j["name"] != "last-modified":
-                objects[i["primary-key"]["attribute"][0]["value"]].append(
+                objects[objectKey].append(
                     {j["name"]: j["value"]}
                 )
     yaml_out = yaml.dump(yaml.full_load(json.dumps(objects)), default_flow_style=False)

--- a/ripe.py
+++ b/ripe.py
@@ -8,7 +8,7 @@ from pprint import pprint
 import requests
 import sys
 import yaml
-
+import re
 
 def ripe_create(db, pwd, json_output, key, type, dryrun, object_entries):
     """
@@ -298,7 +298,10 @@ if __name__ == "__main__":
         yml_objects = yaml_parser(args.objects)
         for key in yml_objects.keys():
             type = list(yml_objects[key][0].keys())[0]
-            name = key
+            if type == "route" or type == "route6":
+                name = re.sub('AS\d+$', '', key)
+            else:
+                name = key
             print("")
             print(type, key)
             ripe_object = ripe_get(args.db, type, name, yml_objects[key])
@@ -326,7 +329,7 @@ if __name__ == "__main__":
                         args.db,
                         pwd,
                         json_output,
-                        key,
+                        name,
                         type,
                         args.dryrun,
                         yml_objects[key],
@@ -336,7 +339,7 @@ if __name__ == "__main__":
                 print(f"Object does not exists in the RIPE database")
                 json_output = yaml_to_json(yml_objects[key])
                 ripe_create(
-                    args.db, pwd, json_output, key, type, args.dryrun, yml_objects[key]
+                    args.db, pwd, json_output, name, type, args.dryrun, yml_objects[key]
                 )
 
     # else if cmdline argument for search is given

--- a/ripe.py
+++ b/ripe.py
@@ -231,15 +231,15 @@ def json_to_yaml(json_payload):
 
     for i in json_payload["objects"]["object"]:
         type = i["type"]
-        primaryKey = i["primary-key"]["attribute"]
-        objectKey = primaryKey[0]["value"]
+        primary_key = i["primary-key"]["attribute"]
+        object_key = primary_key[0]["value"]
         if type == "route" or type == "route6":
-            origin = primaryKey[1]["value"]
-            objectKey = f"{objectKey}{origin}"
-        objects[objectKey] = []
+            origin = primary_key[1]["value"]
+            object_key = f"{object_key}{origin}"
+        objects[object_key] = []
         for j in i["attributes"]["attribute"]:
             if j["name"] != "last-modified":
-                objects[objectKey].append(
+                objects[object_key].append(
                     {j["name"]: j["value"]}
                 )
     yaml_out = yaml.dump(yaml.full_load(json.dumps(objects)), default_flow_style=False)


### PR DESCRIPTION
The YAML output may be incomplete due to inetnum/inet6num objects overwriting route/route6 objects, and vice versa, in the output object due to them having the same keys.

This change appends the origin ASN in the key for route/route6 objects, this behavior is already present in the RIPE update functions; this just pulls that in for `json_to_yaml`.